### PR TITLE
Updated mocha-headless-chrome version to latest in pakcage.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ os:
 language: node_js
 node_js:
   - node
+  - '14'
   - '12'
   - '10'
-  - '8'
 git:
   depth: 10

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "esm": "^3.2.22",
     "gulp-format-md": "^1.0.0",
     "mocha": "^6.1.4",
-    "mocha-headless-chrome": "^2.0.2",
+    "mocha-headless-chrome": "^3.1.0",
     "rollup": "^1.10.1",
     "rollup-plugin-node-resolve": "^4.2.3"
   },


### PR DESCRIPTION
Updated mocha-headless-chrome to latest in package.json as the latest version
has support for aarch64 platform. Updated Travis.yml to use latest nodejs versions as puppeteer doesn't support older versions.