### PR TITLE
Still pass if constructor key is a primitive

### DIFF
--- a/is-plain-object.js
+++ b/is-plain-object.js
@@ -9,6 +9,25 @@ function isObject(o) {
   return Object.prototype.toString.call(o) === '[object Object]';
 }
 
+/**
+ * Returns if the encountered value is a native value that we can parse
+ * or process. This is basically the javascript typeof but with added
+ * support for null.
+ *
+ * @param {*} value
+ *
+ * @returns {boolean}
+ */
+function isPrimitive (value) {
+  if (value === null) {
+    return true;
+  }
+  return ['undefined', 'boolean', 'number', 'string', 'bigint'].includes(
+    typeof value
+  );
+}
+
+
 export function isPlainObject(o) {
   var ctor,prot;
 
@@ -16,7 +35,7 @@ export function isPlainObject(o) {
 
   // If has modified constructor
   ctor = o.constructor;
-  if (ctor === undefined) return true;
+  if (ctor === undefined || isPrimitive(ctor)) return true;
 
   // If has modified prototype
   prot = ctor.prototype;

--- a/test/server.js
+++ b/test/server.js
@@ -13,12 +13,13 @@ describe('Same-Realm Server Tests', function() {
     assert(isPlainObject(Object.create({})));
     assert(isPlainObject(Object.create(Object.prototype)));
     assert(isPlainObject({foo: 'bar'}));
+    assert(isPlainObject({constructor: 'not actually a constructor'}));
     assert(isPlainObject({}));
     assert(isPlainObject(Object.create(null)));
   });
 
   it('should return `false` if the object is not created by the `Object` constructor.', function() {
-    function Foo() {this.abc = {};};
+    function Foo() {this.abc = {};}
 
     assert(!isPlainObject(/foo/));
     assert(!isPlainObject(function() {}));


### PR DESCRIPTION
I added a test. If the constructor is a primitive, then this should still be considered a plain object because it isn't being created with a constructor.