### PR TITLE
feat: use a type guard for the function

### DIFF
--- a/is-plain-object.d.ts
+++ b/is-plain-object.d.ts
@@ -1,1 +1,6 @@
-export function isPlainObject(o: any): boolean;
+/**
+ * Returns true if an object was created by the `Object` constructor, or Object.create(null).
+ * 
+ * @param value The value to test
+ */
+export function isPlainObject(value: unknown): value is Record<PropertyKey, unknown>;


### PR DESCRIPTION
Breaking change: The typings now require TS v3.0 (released in 2018) due to switching `any` to `unknown`.