### PR TITLE
fix: missing types entry in package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "import": "./dist/is-plain-object.mjs",
-      "require": "./dist/is-plain-object.js"
+      "require": "./dist/is-plain-object.js",
+      "types": "./is-plain-object.d.ts"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Typescript complains it can't find the types when using ESM, so I updated the `exports` config to include `types` and it stopped complaining 👍. With this change type checking and bundling now works in ESM projects (or I guess newer node versions/typescript versions that support `exports`).