### PR TITLE
fix(package.json): types not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "import": "./dist/is-plain-object.mjs",
-      "require": "./dist/is-plain-object.js"
+      "require": "./dist/is-plain-object.js",
+      "types": "./is-plain-object.d.ts",
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Since `exports` is defined in `package.json`, `types` must also be defined under `.` path. Otherwise, typescript won't find it.