### PR TITLE
fix: add default export condition for ESM module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "import": "./dist/is-plain-object.mjs",
-      "require": "./dist/is-plain-object.js"
+      "require": "./dist/is-plain-object.js",
+      "default": "./dist/is-plain-object.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
## Summary

This PR adds a `"default"` export condition to the package.json exports field.

## Problem

Some bundlers and runtimes don't match the `"import"` or `"require"` conditions when resolving ESM modules. This can cause module resolution failures in certain environments.

For example, when using tools that resolve modules in a neutral/unknown module system context (neither explicitly CommonJS nor ESM), they may not match either condition, causing the import to fail.

## Solution

Adding the `"default"` condition as a fallback ensures the module can be properly resolved in all environments. According to the Node.js documentation, the `"default"` condition should always be defined last as a generic fallback.

```json
"exports": {
  ".": {
    "import": "./dist/is-plain-object.mjs",
    "require": "./dist/is-plain-object.js",
    "default": "./dist/is-plain-object.js"
  },
  "./package.json": "./package.json"
}
```

## References

- [Node.js Conditional Exports Documentation](https://nodejs.org/api/packages.html#conditional-exports)